### PR TITLE
feat(ai): AI assistant via AWS Bedrock (Claude) + lightweight names endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN npm ci
 
 COPY . .
 
-RUN npx nest build --builder tsc && ls dist/main.js
+RUN npx nest build --builder tsc && ls dist/src/main.js
 
 RUN npx prisma generate
 
@@ -41,4 +41,4 @@ RUN npm prune --omit=dev
 
 EXPOSE 3000
 
-CMD ["sh", "-c", "npx prisma migrate deploy && node dist/main"]
+CMD ["sh", "-c", "npx prisma migrate deploy && node dist/src/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN npm ci
 
 COPY . .
 
-RUN npx nest build && ls dist/main.js
+RUN npx nest build --builder tsc && ls dist/main.js
 
 RUN npx prisma generate
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY prisma ./prisma/
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+
+FROM node:20-slim
+
+WORKDIR /app
+
+# Dependencias de sistema para Puppeteer/Chromium
+RUN apt-get update && apt-get install -y \
+    chromium \
+    fonts-liberation \
+    libappindicator3-1 \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libgdk-pixbuf2.0-0 \
+    libnspr4 \
+    libnss3 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    xdg-utils \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+COPY package*.json ./
+COPY prisma ./prisma/
+
+RUN npm ci --omit=dev && npx prisma generate
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3000
+
+CMD ["sh", "-c", "npx prisma migrate deploy && node dist/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,3 @@
-FROM node:20-slim AS builder
-
-WORKDIR /app
-
-COPY package*.json ./
-COPY prisma ./prisma/
-
-RUN npm ci
-
-COPY . .
-
-RUN npm run build
-
-
 FROM node:20-slim
 
 WORKDIR /app
@@ -43,9 +29,15 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 COPY package*.json ./
 COPY prisma ./prisma/
 
-RUN npm ci --omit=dev && npx prisma generate
+RUN npm ci
 
-COPY --from=builder /app/dist ./dist
+COPY . .
+
+RUN npx nest build && ls dist/main.js
+
+RUN npx prisma generate
+
+RUN npm prune --omit=dev
 
 EXPOSE 3000
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@anthropic-ai/bedrock-sdk": "^0.30.1",
         "@fastify/cookie": "^11.0.2",
         "@fastify/multipart": "^9.0.3",
         "@fastify/static": "^8.1.1",
@@ -218,6 +219,949 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.30.1.tgz",
+      "integrity": "sha512-zYf3yHJK6C4r9bOVCfeEWasdKercgmfV8FZfewXOovMzZVx/8O6KRBA0005VBjKYWCIJo0d1pW83yi0DyoAedw==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": ">=0.50.3 <1",
+        "@aws-crypto/sha256-js": "^4.0.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.797.0",
+        "@aws-sdk/credential-providers": "^3.796.0",
+        "@smithy/eventstream-serde-node": "^2.0.10",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/signature-v4": "^3.1.1",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-base64": "^2.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@anthropic-ai/sdk": {
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
+      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-4.0.0.tgz",
+      "integrity": "sha512-MHGJyjE7TX9aaqXj7zk2ppnFUOhaDs5sP+HtNS0evOxn72c+5njUmyJmpGd7TfyoDznZlHMmdo/xGUdu2NIjNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^4.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-4.0.0.tgz",
+      "integrity": "sha512-2EnmPy2gsFZ6m8bwUQN4jq+IyXV3quHAcwPOS6ZA3k+geujiqI8aRokO2kFJe+idJ/P3v4qWI186rVMo0+zLDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1064.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1064.0.tgz",
+      "integrity": "sha512-TA9+5fuhr4cVwJEtxf/j3iCujgpvJ8SQCAuiu62QOPrak3aUh492m54y9vPy1GEv/OKlUbOpW8i91If9f0SmYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/credential-provider-node": "^3.972.53",
+        "@aws-sdk/eventstream-handler-node": "^3.972.21",
+        "@aws-sdk/middleware-eventstream": "^3.972.17",
+        "@aws-sdk/middleware-websocket": "^3.972.27",
+        "@aws-sdk/token-providers": "3.1064.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.1064.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1064.0.tgz",
+      "integrity": "sha512-yBrVvup9ePyCdWTlTiJqTdOXv8TVmEyMvGn1uENveycVyDnCVWiNFvHpbCJDqt7qgBqrafb25KVTknVWSvfDgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/credential-provider-node": "^3.972.53",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.19.tgz",
+      "integrity": "sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.43.tgz",
+      "integrity": "sha512-ScgOiNqm73gkNo00JXwWlrXGfv60SX+dRvtj3bQacDZviUc7vd0UOC60wfcy/1iZZ5UfEFMh055Gu/HWLGN2MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.45.tgz",
+      "integrity": "sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.47.tgz",
+      "integrity": "sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.51.tgz",
+      "integrity": "sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/credential-provider-env": "^3.972.45",
+        "@aws-sdk/credential-provider-http": "^3.972.47",
+        "@aws-sdk/credential-provider-login": "^3.972.50",
+        "@aws-sdk/credential-provider-process": "^3.972.45",
+        "@aws-sdk/credential-provider-sso": "^3.972.50",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.50.tgz",
+      "integrity": "sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.53.tgz",
+      "integrity": "sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.45",
+        "@aws-sdk/credential-provider-http": "^3.972.47",
+        "@aws-sdk/credential-provider-ini": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.45",
+        "@aws-sdk/credential-provider-sso": "^3.972.50",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.45.tgz",
+      "integrity": "sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.50.tgz",
+      "integrity": "sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/token-providers": "3.1064.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.50.tgz",
+      "integrity": "sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.1064.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1064.0.tgz",
+      "integrity": "sha512-Muq/z9gqjUhsFhIqtZnovJoUCP8HW27EZoRbjtMJiUa5gcdjK2Q+2NYHn/3XnaqnyAjjrDOCP2xwn651qvKarQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.1064.0",
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.43",
+        "@aws-sdk/credential-provider-env": "^3.972.45",
+        "@aws-sdk/credential-provider-http": "^3.972.47",
+        "@aws-sdk/credential-provider-ini": "^3.972.51",
+        "@aws-sdk/credential-provider-login": "^3.972.50",
+        "@aws-sdk/credential-provider-node": "^3.972.53",
+        "@aws-sdk/credential-provider-process": "^3.972.45",
+        "@aws-sdk/credential-provider-sso": "^3.972.50",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.21.tgz",
+      "integrity": "sha512-mVC0hOmwGJmNFezZ+wM8Sqfap/LjsMavEf2Evl0YWrLAcrdZOEdjnY8nRvgakVViWJSGm2eJxLuPVHGdeV06kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.17.tgz",
+      "integrity": "sha512-tdbnXbw73ww62ABWP0G0Z/euvFowEEvAoi/zG4NaZo7HJFpfGho/Z65HyVzkJLT1cMsUregr4pTyxljlarT0wA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.27.tgz",
+      "integrity": "sha512-V/IgUogQm/NSGlNglDCkREirQXgjyrrq64vPt5qcRTGhEJJwPcUB3RyYE6iZ63WNGp4Ezc+JtVRA4QlSbhDvVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.18.tgz",
+      "integrity": "sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
+      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1064.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1064.0.tgz",
+      "integrity": "sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
+      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -674,7 +1618,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
       "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -3885,6 +4828,18 @@
         }
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4141,10 +5096,626 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec/node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec/node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-codec/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/util-middleware": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder/node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
+      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/cli": {
@@ -6277,6 +7848,12 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -8715,6 +10292,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -8730,6 +10313,43 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastify": {
       "version": "5.2.1",
@@ -11395,6 +13015,19 @@
         "url": "https://github.com/Eomm/json-schema-resolver?sponsor=1"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -13584,6 +15217,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -14561,8 +16209,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/relateurl": {
       "version": "0.2.7",
@@ -15651,6 +17298,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -15909,6 +17566,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/strtok3": {
       "version": "9.1.1",
@@ -16455,6 +18124,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.0.1",
@@ -17547,6 +19222,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
+        "@faker-js/faker": "^10.4.0",
         "@nestjs/cli": "^11.0.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.12",
@@ -1536,6 +1537,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@fastify/accept-negotiator": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@anthropic-ai/bedrock-sdk": "^0.30.1",
     "@fastify/cookie": "^11.0.2",
     "@fastify/multipart": "^9.0.3",
     "@fastify/static": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "npm run build && node --max-old-space-size=512 dist/main",
+    "start:prod": "npm run build && node --max-old-space-size=512 dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
+    "@faker-js/faker": "^10.4.0",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.12",
@@ -95,6 +96,9 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,352 @@
+import { PrismaClient, documentType, Status, Prisma } from '@prisma/client';
+import { faker } from '@faker-js/faker';
+import * as bcrypt from 'bcrypt';
+
+const prisma = new PrismaClient();
+
+// ============================================================
+//  Cantidades a generar — ajústalas según necesites
+// ============================================================
+const COUNTS = {
+  users: 50,
+  clients: 1000,
+  suppliers: 50,
+  categories: 20,
+  tags: 15,
+  products: 2000,
+  batchesPerProduct: 2, // lotes por producto
+  sales: 5000,
+  maxProductsPerSale: 4, // líneas máximas por venta
+};
+
+// Inserta en bloques para no saturar la conexión
+const CHUNK = 1000;
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+async function createManyChunked<T>(
+  label: string,
+  rows: T[],
+  insert: (batch: T[]) => Promise<unknown>,
+) {
+  let done = 0;
+  for (const part of chunk(rows, CHUNK)) {
+    await insert(part);
+    done += part.length;
+    process.stdout.write(`\r   ${label}: ${done}/${rows.length}`);
+  }
+  process.stdout.write('\n');
+}
+
+async function main() {
+  console.time('seed');
+  faker.seed(123); // datos reproducibles
+  console.log('🌱 Iniciando seed masivo...\n');
+
+  // ----- Limpieza (orden inverso por las relaciones) -----
+  console.log('🧹 Limpiando tablas...');
+  await prisma.saleBatch.deleteMany();
+  await prisma.saleProductClient.deleteMany();
+  await prisma.sale.deleteMany();
+  await prisma.productTag.deleteMany();
+  await prisma.productImage.deleteMany();
+  await prisma.batch.deleteMany();
+  await prisma.product.deleteMany();
+  await prisma.tag.deleteMany();
+  await prisma.category.deleteMany();
+  await prisma.supplier.deleteMany();
+  await prisma.client.deleteMany();
+  await prisma.user.deleteMany();
+
+  // ============================================================
+  //  Usuarios
+  // ============================================================
+  const hashedPassword = await bcrypt.hash('Admin123*', 10);
+  const users: Prisma.UserCreateManyInput[] = [
+    {
+      id: '1000000001',
+      documentType: documentType.CC,
+      name: 'Administrador Principal',
+      phone: '3001112233',
+      email: 'admin@nuevaesperanza.online',
+      password: hashedPassword,
+      birthdate: new Date('1990-01-15'),
+      status: Status.ACTIVE,
+      isAdmin: true,
+      isEmployee: false,
+    },
+  ];
+  const usedUserIds = new Set<string>(['1000000001']);
+  while (users.length < COUNTS.users) {
+    const id = faker.string.numeric(10);
+    if (usedUserIds.has(id)) continue;
+    usedUserIds.add(id);
+    users.push({
+      id,
+      documentType: documentType.CC,
+      name: faker.person.fullName(),
+      phone: `3${faker.string.numeric(9)}`,
+      email: faker.internet.email().toLowerCase(),
+      password: hashedPassword,
+      birthdate: faker.date.birthdate({ min: 18, max: 65, mode: 'age' }),
+      status: Status.ACTIVE,
+      isAdmin: false,
+      isEmployee: true,
+    });
+  }
+  await createManyChunked('Usuarios', users, (b) =>
+    prisma.user.createMany({ data: b, skipDuplicates: true }),
+  );
+  const employeeNames = users.map((u) => u.name);
+
+  // ============================================================
+  //  Clientes
+  // ============================================================
+  const clients: Prisma.ClientCreateManyInput[] = [];
+  const usedClientIds = new Set<string>();
+  while (clients.length < COUNTS.clients) {
+    const id = faker.string.numeric(10);
+    if (usedClientIds.has(id)) continue;
+    usedClientIds.add(id);
+    clients.push({
+      id,
+      name: faker.person.fullName(),
+      email: faker.internet.email().toLowerCase(),
+      phone: `3${faker.string.numeric(9)}`,
+    });
+  }
+  await createManyChunked('Clientes', clients, (b) =>
+    prisma.client.createMany({ data: b, skipDuplicates: true }),
+  );
+  const clientIds = clients.map((c) => c.id);
+
+  // ============================================================
+  //  Proveedores
+  // ============================================================
+  const suppliers: Prisma.SupplierCreateManyInput[] = [];
+  const usedSupplierEmails = new Set<string>();
+  while (suppliers.length < COUNTS.suppliers) {
+    const email = faker.internet.email().toLowerCase();
+    if (usedSupplierEmails.has(email)) continue;
+    usedSupplierEmails.add(email);
+    suppliers.push({
+      id: faker.string.uuid(),
+      name: faker.company.name(),
+      phone: `60${faker.string.numeric(8)}`,
+      email,
+      status: Status.ACTIVE,
+    });
+  }
+  await createManyChunked('Proveedores', suppliers, (b) =>
+    prisma.supplier.createMany({ data: b, skipDuplicates: true }),
+  );
+  const supplierIds = suppliers.map((s) => s.id!);
+
+  // ============================================================
+  //  Categorías
+  // ============================================================
+  const categories: Prisma.CategoryCreateManyInput[] = Array.from(
+    { length: COUNTS.categories },
+    () => ({
+      id: faker.string.uuid(),
+      name: faker.commerce.department(),
+    }),
+  );
+  await prisma.category.createMany({ data: categories, skipDuplicates: true });
+  console.log(`   Categorías: ${categories.length}/${categories.length}`);
+  const categoryIds = categories.map((c) => c.id!);
+
+  // ============================================================
+  //  Tags
+  // ============================================================
+  const tags: Prisma.TagCreateManyInput[] = Array.from(
+    { length: COUNTS.tags },
+    () => ({ id: faker.string.uuid(), name: faker.commerce.productAdjective() }),
+  );
+  await prisma.tag.createMany({ data: tags, skipDuplicates: true });
+  console.log(`   Tags: ${tags.length}/${tags.length}`);
+  const tagIds = tags.map((t) => t.id!);
+
+  // ============================================================
+  //  Productos (+ Tags, Imágenes, Lotes)
+  // ============================================================
+  const products: Prisma.ProductCreateManyInput[] = [];
+  const productTags: Prisma.ProductTagCreateManyInput[] = [];
+  const productImages: Prisma.ProductImageCreateManyInput[] = [];
+  const batches: Prisma.BatchCreateManyInput[] = [];
+  // guardamos lotes por producto para usarlos en las ventas
+  const batchesByProduct = new Map<string, { id: string; available: number }[]>();
+
+  for (let i = 0; i < COUNTS.products; i++) {
+    const id = faker.string.uuid();
+    const price = faker.number.int({ min: 1000, max: 80000 });
+    products.push({
+      id,
+      barcode: faker.string.numeric(13),
+      name: faker.commerce.productName(),
+      description: faker.commerce.productDescription().slice(0, 200),
+      categoryId: faker.helpers.arrayElement(categoryIds),
+      supplierId: faker.helpers.arrayElement(supplierIds),
+      price,
+      concentration: faker.helpers.arrayElement(['250mg', '500mg', '1g', '5ml', null]),
+      activeIngredient: faker.helpers.arrayElement([
+        'Acetaminofén',
+        'Ibuprofeno',
+        'Amoxicilina',
+        'Loratadina',
+        null,
+      ]),
+    });
+
+    // tags (1-3 distintos por producto)
+    const productTagIds = faker.helpers.arrayElements(
+      tagIds,
+      faker.number.int({ min: 1, max: 3 }),
+    );
+    for (const tagId of productTagIds) {
+      productTags.push({ id: faker.string.uuid(), productId: id, tagId });
+    }
+
+    // 1 imagen por producto
+    productImages.push({
+      id: faker.string.uuid(),
+      productId: id,
+      url: faker.image.url(),
+    });
+
+    // lotes
+    const productBatches: { id: string; available: number }[] = [];
+    for (let b = 0; b < COUNTS.batchesPerProduct; b++) {
+      const batchId = faker.string.uuid();
+      const amount = faker.number.int({ min: 20, max: 300 });
+      batches.push({
+        id: batchId,
+        productId: id,
+        number_batch: `L-${faker.string.alphanumeric(6).toUpperCase()}`,
+        expirationDate: faker.date.future({ years: 3 }),
+        entryDate: faker.date.recent({ days: 365 }),
+        amount,
+        available_amount: amount,
+        purchaseValue: Math.round(price * 0.6),
+      });
+      productBatches.push({ id: batchId, available: amount });
+    }
+    batchesByProduct.set(id, productBatches);
+  }
+
+  await createManyChunked('Productos', products, (b) =>
+    prisma.product.createMany({ data: b, skipDuplicates: true }),
+  );
+  await createManyChunked('ProductTags', productTags, (b) =>
+    prisma.productTag.createMany({ data: b, skipDuplicates: true }),
+  );
+  await createManyChunked('Imágenes', productImages, (b) =>
+    prisma.productImage.createMany({ data: b, skipDuplicates: true }),
+  );
+  await createManyChunked('Lotes', batches, (b) =>
+    prisma.batch.createMany({ data: b, skipDuplicates: true }),
+  );
+
+  const productList = products.map((p) => ({ id: p.id!, price: Number(p.price) }));
+
+  // ============================================================
+  //  Ventas (+ SaleProductClient, SaleBatch) y descuento de stock
+  // ============================================================
+  const sales: Prisma.SaleCreateManyInput[] = [];
+  const saleProducts: Prisma.SaleProductClientCreateManyInput[] = [];
+  const saleBatches: Prisma.SaleBatchCreateManyInput[] = [];
+
+  for (let i = 0; i < COUNTS.sales; i++) {
+    const saleId = faker.string.uuid();
+    const lineCount = faker.number.int({ min: 1, max: COUNTS.maxProductsPerSale });
+    const chosen = faker.helpers.arrayElements(productList, lineCount);
+
+    let total = 0;
+    const lines: {
+      saleProductId: string;
+      productId: string;
+      amount: number;
+    }[] = [];
+
+    for (const prod of chosen) {
+      const available = batchesByProduct.get(prod.id) ?? [];
+      const batchWithStock = available.find((b) => b.available > 0);
+      if (!batchWithStock) continue;
+
+      const amount = faker.number.int({
+        min: 1,
+        max: Math.min(5, batchWithStock.available),
+      });
+      const saleProductId = faker.string.uuid();
+
+      saleProducts.push({ id: saleProductId, saleId, productId: prod.id, amount });
+      saleBatches.push({
+        id: faker.string.uuid(),
+        saleProductId,
+        batchId: batchWithStock.id,
+        quantity: amount,
+      });
+      batchWithStock.available -= amount;
+      total += prod.price * amount;
+      lines.push({ saleProductId, productId: prod.id, amount });
+    }
+
+    if (lines.length === 0) continue;
+
+    sales.push({
+      id: saleId,
+      clientId: faker.helpers.arrayElement(clientIds),
+      employeeName: faker.helpers.arrayElement(employeeNames),
+      total,
+      date: faker.date.recent({ days: 180 }),
+      bill_id: i + 1,
+    });
+  }
+
+  await createManyChunked('Ventas', sales, (b) =>
+    prisma.sale.createMany({ data: b, skipDuplicates: true }),
+  );
+  await createManyChunked('Líneas de venta', saleProducts, (b) =>
+    prisma.saleProductClient.createMany({ data: b, skipDuplicates: true }),
+  );
+  await createManyChunked('Venta-Lote', saleBatches, (b) =>
+    prisma.saleBatch.createMany({ data: b, skipDuplicates: true }),
+  );
+
+  // Actualiza el stock disponible de cada lote afectado
+  console.log('🔄 Actualizando stock de lotes...');
+  let stockUpdates = 0;
+  for (const [, productBatches] of batchesByProduct) {
+    for (const b of productBatches) {
+      await prisma.batch.update({
+        where: { id: b.id },
+        data: { available_amount: b.available },
+      });
+      stockUpdates++;
+    }
+  }
+  console.log(`   Lotes actualizados: ${stockUpdates}`);
+
+  console.log('\n✅ Seed masivo completado:');
+  console.log(`   - ${users.length} usuarios (contraseña: Admin123*)`);
+  console.log(`   - ${clients.length} clientes`);
+  console.log(`   - ${suppliers.length} proveedores`);
+  console.log(`   - ${categories.length} categorías, ${tags.length} tags`);
+  console.log(`   - ${products.length} productos`);
+  console.log(`   - ${batches.length} lotes`);
+  console.log(`   - ${sales.length} ventas`);
+  console.timeEnd('seed');
+}
+
+main()
+  .catch((e) => {
+    console.error('\n❌ Error en el seed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,11 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "sh -c 'npx prisma migrate deploy && node dist/main'"
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3
+
+[[services]]
+internalPort = 3000

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "sh -c 'npx prisma migrate deploy && node dist/main'"
+startCommand = "sh -c 'npx prisma migrate deploy && node dist/src/main'"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3
 

--- a/src/ai/ai.controller.ts
+++ b/src/ai/ai.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { AiService } from './ai.service';
+import { RunAiDto } from './dto/run-ai.dto';
+import { AuthGuard } from 'src/auth/guard/auth.guard';
+
+@Controller('ai')
+export class AiController {
+  constructor(private readonly aiService: AiService) {}
+
+  @UseGuards(AuthGuard)
+  @Post('run')
+  run(@Body() runAiDto: RunAiDto) {
+    return this.aiService.run(runAiDto);
+  }
+}

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AiController } from './ai.controller';
+import { AiService } from './ai.service';
+
+@Module({
+  controllers: [AiController],
+  providers: [AiService],
+})
+export class AiModule {}

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -1,0 +1,130 @@
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { RunAiDto } from './dto/run-ai.dto';
+
+interface GeminiResponse {
+  candidates?: Array<{
+    content?: { parts?: Array<{ text?: string }> };
+    finishReason?: string;
+  }>;
+  promptFeedback?: { blockReason?: string };
+}
+
+@Injectable()
+export class AiService {
+  private readonly logger = new Logger(AiService.name);
+  // Modelo Flash configurable por entorno; valor por defecto si no se define.
+  private readonly model = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+
+  async run({
+    context,
+    question,
+    restrictions,
+  }: RunAiDto): Promise<{ answer: string }> {
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      this.logger.error('GEMINI_API_KEY no está configurada');
+      throw new InternalServerErrorException(
+        'El servicio de IA no está configurado',
+      );
+    }
+
+    const prompt = this.buildPrompt(context, question, restrictions);
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent`;
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': apiKey,
+        },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0.4, maxOutputTokens: 2048 },
+        }),
+      });
+    } catch (err) {
+      this.logger.error(`Error de red al contactar Gemini: ${err}`);
+      throw new HttpException(
+        'No se pudo contactar al servicio de IA',
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      this.logger.error(`Gemini respondió ${response.status}: ${detail}`);
+      if (response.status === 429) {
+        throw new HttpException(
+          'Límite de uso de IA alcanzado, intenta más tarde',
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
+      if (response.status === 503) {
+        throw new HttpException(
+          'El servicio de IA está temporalmente saturado, intenta de nuevo en unos segundos',
+          HttpStatus.SERVICE_UNAVAILABLE,
+        );
+      }
+      throw new HttpException(
+        'Error al obtener respuesta de la IA',
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+
+    const data = (await response.json()) as GeminiResponse;
+    const answer =
+      data.candidates?.[0]?.content?.parts
+        ?.map((part) => part.text ?? '')
+        .join('')
+        .trim() ?? '';
+
+    if (!answer) {
+      const blockReason = data.promptFeedback?.blockReason;
+      this.logger.warn(
+        `Gemini devolvió respuesta vacía (blockReason=${blockReason ?? 'none'})`,
+      );
+      throw new HttpException(
+        'La IA no devolvió una respuesta',
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+
+    return { answer };
+  }
+
+  // Replica el armado de prompt que magicloops hacía por dentro:
+  // combina las reglas de negocio, el contexto (JSON) y la pregunta.
+  private buildPrompt(
+    context: unknown,
+    question: string,
+    restrictions?: string,
+  ): string {
+    const reglas = restrictions?.trim()
+      ? restrictions.trim()
+      : 'Responde de forma breve, clara y útil.';
+    const contextoJson = JSON.stringify(context ?? {});
+
+    return [
+      'Eres un asistente para una farmacia. Respondes siempre en español.',
+      '',
+      'REGLAS:',
+      reglas,
+      '',
+      'CONTEXTO (ventas, productos, categorías y predicciones en formato JSON):',
+      contextoJson,
+      '',
+      'PREGUNTA DEL USUARIO:',
+      question,
+      '',
+      'Responde únicamente con la respuesta para el usuario, sin repetir estas instrucciones.',
+    ].join('\n');
+  }
+}

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -5,92 +5,61 @@ import {
   InternalServerErrorException,
   Logger,
 } from '@nestjs/common';
+import { AnthropicBedrock } from '@anthropic-ai/bedrock-sdk';
 import { RunAiDto } from './dto/run-ai.dto';
-
-interface GeminiResponse {
-  candidates?: Array<{
-    content?: { parts?: Array<{ text?: string }> };
-    finishReason?: string;
-  }>;
-  promptFeedback?: { blockReason?: string };
-}
 
 @Injectable()
 export class AiService {
   private readonly logger = new Logger(AiService.name);
-  // Modelo Flash configurable por entorno; valor por defecto si no se define.
-  private readonly model = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+
+  // Región de AWS donde está habilitado el modelo en Bedrock.
+  private readonly region = process.env.AWS_REGION || 'us-east-1';
+
+  // ID del modelo (o perfil de inferencia) en Bedrock. Debe copiarse EXACTO
+  // desde la consola de Bedrock; los modelos Claude recientes usan un perfil
+  // de inferencia con prefijo de región, p. ej.:
+  //   us.anthropic.claude-haiku-4-5-20251001-v1:0
+  private readonly model = process.env.BEDROCK_MODEL || '';
+
+  // Cliente Bedrock. Las credenciales se toman de la cadena estándar de AWS
+  // (variables de entorno AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY), así que
+  // no se exponen claves en el código.
+  private readonly client = new AnthropicBedrock({ awsRegion: this.region });
 
   async run({
     context,
     question,
     restrictions,
   }: RunAiDto): Promise<{ answer: string }> {
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      this.logger.error('GEMINI_API_KEY no está configurada');
+    if (!this.model) {
+      this.logger.error('BEDROCK_MODEL no está configurado');
       throw new InternalServerErrorException(
         'El servicio de IA no está configurado',
       );
     }
 
-    const prompt = this.buildPrompt(context, question, restrictions);
-    const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent`;
+    const system = this.buildSystemPrompt(context, restrictions);
 
-    let response: Response;
+    let answer: string;
     try {
-      response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-goog-api-key': apiKey,
-        },
-        body: JSON.stringify({
-          contents: [{ role: 'user', parts: [{ text: prompt }] }],
-          generationConfig: { temperature: 0.4, maxOutputTokens: 2048 },
-        }),
+      const message = await this.client.messages.create({
+        model: this.model,
+        max_tokens: 2048,
+        temperature: 0.4,
+        system,
+        messages: [{ role: 'user', content: question }],
       });
+
+      const raw = message.content
+        .map((block) => (block.type === 'text' ? block.text : ''))
+        .join('');
+      answer = this.stripMarkdown(raw);
     } catch (err) {
-      this.logger.error(`Error de red al contactar Gemini: ${err}`);
-      throw new HttpException(
-        'No se pudo contactar al servicio de IA',
-        HttpStatus.BAD_GATEWAY,
-      );
+      throw this.mapError(err);
     }
-
-    if (!response.ok) {
-      const detail = await response.text().catch(() => '');
-      this.logger.error(`Gemini respondió ${response.status}: ${detail}`);
-      if (response.status === 429) {
-        throw new HttpException(
-          'Límite de uso de IA alcanzado, intenta más tarde',
-          HttpStatus.TOO_MANY_REQUESTS,
-        );
-      }
-      if (response.status === 503) {
-        throw new HttpException(
-          'El servicio de IA está temporalmente saturado, intenta de nuevo en unos segundos',
-          HttpStatus.SERVICE_UNAVAILABLE,
-        );
-      }
-      throw new HttpException(
-        'Error al obtener respuesta de la IA',
-        HttpStatus.BAD_GATEWAY,
-      );
-    }
-
-    const data = (await response.json()) as GeminiResponse;
-    const answer =
-      data.candidates?.[0]?.content?.parts
-        ?.map((part) => part.text ?? '')
-        .join('')
-        .trim() ?? '';
 
     if (!answer) {
-      const blockReason = data.promptFeedback?.blockReason;
-      this.logger.warn(
-        `Gemini devolvió respuesta vacía (blockReason=${blockReason ?? 'none'})`,
-      );
+      this.logger.warn('Bedrock devolvió una respuesta vacía');
       throw new HttpException(
         'La IA no devolvió una respuesta',
         HttpStatus.BAD_GATEWAY,
@@ -100,13 +69,59 @@ export class AiService {
     return { answer };
   }
 
-  // Replica el armado de prompt que magicloops hacía por dentro:
-  // combina las reglas de negocio, el contexto (JSON) y la pregunta.
-  private buildPrompt(
-    context: unknown,
-    question: string,
-    restrictions?: string,
-  ): string {
+  // Traduce los errores del SDK de Bedrock a respuestas HTTP claras para el
+  // frontend, conservando los mensajes que ya manejaba la app.
+  private mapError(err: unknown): HttpException {
+    const status =
+      typeof err === 'object' && err !== null && 'status' in err
+        ? (err as { status?: number }).status
+        : undefined;
+
+    this.logger.error(`Bedrock respondió ${status ?? 'error desconocido'}: ${err}`);
+
+    if (status === 429) {
+      return new HttpException(
+        'Límite de uso de IA alcanzado, intenta más tarde',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+    if (status === 403) {
+      // Credenciales sin permiso sobre el modelo o acceso al modelo no
+      // habilitado en la consola de Bedrock: es un fallo de configuración.
+      return new InternalServerErrorException(
+        'El servicio de IA no está configurado correctamente',
+      );
+    }
+    if (status === 503 || status === 500) {
+      return new HttpException(
+        'El servicio de IA está temporalmente saturado, intenta de nuevo en unos segundos',
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
+    return new HttpException(
+      'Error al obtener respuesta de la IA',
+      HttpStatus.BAD_GATEWAY,
+    );
+  }
+
+  // Elimina la sintaxis de markdown con asteriscos que a veces emite el modelo
+  // (negritas **texto**, cursivas *texto* y viñetas "* "). El frontend muestra
+  // las respuestas como texto plano, así que estos símbolos se verían crudos.
+  private stripMarkdown(text: string): string {
+    return text
+      // Negritas: **texto** -> texto
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      // Viñetas al inicio de línea: "* item" -> "- item"
+      .replace(/^[ \t]*\*[ \t]+/gm, '- ')
+      // Cualquier asterisco suelto restante (cursivas, marcadores sobrantes)
+      .replace(/\*/g, '')
+      .trim();
+  }
+
+  // Arma el prompt de sistema: marco del negocio + reglas + contexto (JSON).
+  // La pregunta del usuario va aparte, como mensaje de usuario, para que el
+  // modelo distinga claramente las instrucciones de la consulta.
+  private buildSystemPrompt(context: unknown, restrictions?: string): string {
     const reglas = restrictions?.trim()
       ? restrictions.trim()
       : 'Responde de forma breve, clara y útil.';
@@ -120,9 +135,6 @@ export class AiService {
       '',
       'CONTEXTO (ventas, productos, categorías y predicciones en formato JSON):',
       contextoJson,
-      '',
-      'PREGUNTA DEL USUARIO:',
-      question,
       '',
       'Responde únicamente con la respuesta para el usuario, sin repetir estas instrucciones.',
     ].join('\n');

--- a/src/ai/dto/run-ai.dto.ts
+++ b/src/ai/dto/run-ai.dto.ts
@@ -1,0 +1,14 @@
+import { IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
+
+export class RunAiDto {
+  @IsObject()
+  context: Record<string, unknown>;
+
+  @IsNotEmpty()
+  @IsString()
+  question: string;
+
+  @IsOptional()
+  @IsString()
+  restrictions?: string;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,9 +12,10 @@ import { SalesModule } from './sales/sales.module';
 import { CloudinaryModule } from './cloudinary/cloudinary.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { TwilioModule } from './twilio/twilio.module';
+import { AiModule } from './ai/ai.module';
 
 @Module({
-  imports: [AuthModule, UsersModule, CategoryModule, SupplierModule, ProductsModule, BatchModule, TagModule, ClientModule, SalesModule, CloudinaryModule, ScheduleModule.forRoot(), DashboardModule, TwilioModule],
+  imports: [AuthModule, UsersModule, CategoryModule, SupplierModule, ProductsModule, BatchModule, TagModule, ClientModule, SalesModule, CloudinaryModule, ScheduleModule.forRoot(), DashboardModule, TwilioModule, AiModule],
   controllers: [],
   providers: [],
 })

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -32,6 +32,11 @@ export class CategoryController {
     return this.categoryService.findAll();
   }
 
+  @Get('names')
+  findAllNames() {
+    return this.categoryService.findAllNames();
+  }
+
   @UseGuards(AuthGuard, RolesGuard)
   @Roles('admin')
   @Get('search')

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -34,6 +34,15 @@ export class CategoryService {
     return await this.prisma.category.findMany();
   }
 
+  // Consulta liviana (id + name + status) para poblar selectores/desplegables
+  // sin traer el resto de campos de la categoría.
+  async findAllNames() {
+    return await this.prisma.category.findMany({
+      select: { id: true, name: true, status: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+
   async findByName(query?: string) {
     const category = await this.prisma.category.findMany({
       where: {

--- a/src/client/client.service.ts
+++ b/src/client/client.service.ts
@@ -88,7 +88,12 @@ export class ClientService {
     }
 
     const code = randomInt(100000, 999999).toString();
-    this.codes.set(email, code); 
+    this.codes.set(email, code);
+
+    // Buscamos el cliente por correo para personalizar el saludo del correo.
+    // Si no existe (p. ej. aún no registrado), usamos un saludo genérico.
+    const client = await this.prisma.client.findFirst({ where: { email } });
+    const name = client?.name ?? 'cliente';
 
     /*
     try {
@@ -111,6 +116,7 @@ export class ClientService {
         3, // Reemplaza con el Template ID de Brevo (verification-code)
         {
           code: code,
+          name: name,
         }
       );
     } catch (error) {

--- a/src/invoice/invoice.service.ts
+++ b/src/invoice/invoice.service.ts
@@ -12,8 +12,14 @@ export class InvoiceService {
         // 1. Cargar la plantilla
         const template = await fs.readFile(templatePath, 'utf-8');
 
+        // ¿Es una nota de crédito (devolución)? Se puede indicar explícitamente
+        // con isCreditNote o, si no, se infiere de que la venta esté devuelta.
+        const isCreditNote = invoiceData.isCreditNote ?? invoiceData.sale.repaid ?? false;
+
         // 3. Renderizar HTML
         const html = mustache.render(template, {
+            isCreditNote,
+            documentTitle: isCreditNote ? 'Nota de Crédito' : 'Factura de venta',
             clientName: invoiceData.clientFound[0].name.toUpperCase(),
             clientId: invoiceData.clientFound[0].id,
             clientEmail: invoiceData.clientFound[0].email,
@@ -29,8 +35,9 @@ export class InvoiceService {
             }),
             invoiceNumber: invoiceData.sale.id || 'No disponible',
             invoiceENumber: invoiceData.sale.number_e_invoice || 'No disponible',
+            creditNoteNumber: invoiceData.sale.number_credit_note || 'No disponible',
             cufe: invoiceData.sale.cufe || 'No disponible',
-            cufeLabel: invoiceData.sale.repaid ? 'CUDE' : 'CUFE',
+            cufeLabel: isCreditNote ? 'CUDE' : 'CUFE',
             qrImage: invoiceData.sale.qr_image || '',
             items: invoiceData.detailedProducts,
             total: invoiceData.sale.total.toFixed(2),

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,8 @@ async function bootstrap() {
         'http://localhost:5173',
         'https://www.drogueriane.site',
         'https://drogueriane.site',
+        'https://www.drogueriane.store',
+        'https://drogueriane.store',
         'https://drogueria.saimers.dev',
         'https://app112.proyectos.fireploy.online'
       ];
@@ -75,7 +77,7 @@ async function bootstrap() {
       if (!origin || allowedOrigins.includes(origin) || regex.test(origin)) {
         callback(null, true);
       } else {
-        callback(new Error('No permitido por CORS'), false);
+        callback(null, false);
       }
     },
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -168,6 +168,14 @@ export class ProductsController {
     return this.productsService.findByNameOnly(query);
   }
 
+  // Devuelve las ventas semanales de TODOS los productos en una sola
+  // respuesta (consumido por el forecasting). Reemplaza el patrón N+1 de
+  // llamar a weekly-sales/:id una vez por producto.
+  @Get('weekly-sales-batch')
+  getWeeklySalesBatch() {
+    return this.productsService.getWeeklySalesLast6MonthsAllProducts();
+  }
+
   @Get('weekly-sales/:id')
   getWeeklySalesByProduct(@Param('id') id: string) {
     return this.productsService.getWeeklySalesLast6Months(id);

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -125,6 +125,11 @@ export class ProductsController {
     return this.productsService.findAll();
   }
 
+  @Get('names')
+  findAllNames() {
+    return this.productsService.findAllNames();
+  }
+
   @Get('for-sale')
   findAllForSale() {
     return this.productsService.findAllForSale();

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -173,6 +173,15 @@ export class ProductsService {
     });
   }
 
+  // Consulta liviana (solo id + name) para poblar selectores/desplegables
+  // sin descargar relaciones (categoría, proveedor, tags, imágenes).
+  async findAllNames() {
+    return await this.prisma.product.findMany({
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+
   async findAllForSale() {
     const products = await this.prisma.product.findMany({
       select: {

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -358,6 +358,94 @@ export class ProductsService {
     }
   }
 
+  // Versión por lote de getWeeklySalesLast6Months: calcula las ventas
+  // semanales (24 semanas) de TODOS los productos con UNA sola consulta a la
+  // base de datos, en vez de una consulta por producto. El forecasting la usa
+  // para evitar el patrón N+1 (~2000 peticiones → 1).
+  async getWeeklySalesLast6MonthsAllProducts() {
+    try {
+      const now = new Date();
+      const colombiaNow = new Date(
+        now.toLocaleString('en-US', { timeZone: 'America/Bogota' }),
+      );
+      const { start: todayStart } = getStartEndOfDayInColombia(colombiaNow);
+      const sixMonthsAgo = startOfWeek(subWeeks(todayStart, 24), {
+        weekStartsOn: 1,
+      });
+
+      // Una sola consulta con TODAS las ventas no reembolsadas de los últimos
+      // 6 meses (campos mínimos), para todos los productos a la vez.
+      const sales = await this.prisma.saleProductClient.findMany({
+        where: {
+          venta: {
+            date: {
+              gte: sixMonthsAgo,
+            },
+            repaid: false,
+          },
+        },
+        select: {
+          productId: true,
+          amount: true,
+          venta: {
+            select: {
+              date: true,
+            },
+          },
+        },
+      });
+
+      // Agrupar en memoria: productId → (semana → totalVentas)
+      const salesByProduct = new Map<string, Map<string, number>>();
+      for (const sale of sales) {
+        const saleDate = new Date(sale.venta.date);
+        const start = startOfWeek(saleDate, { weekStartsOn: 1 });
+        const weekKey = start.toISOString().split('T')[0];
+
+        let weeks = salesByProduct.get(sale.productId);
+        if (!weeks) {
+          weeks = new Map<string, number>();
+          salesByProduct.set(sale.productId, weeks);
+        }
+        weeks.set(weekKey, (weeks.get(weekKey) || 0) + sale.amount);
+      }
+
+      // Definición de las 24 semanas (idéntica a getWeeklySalesLast6Months,
+      // incluido el desfase prevWeekKey, para no cambiar el resultado).
+      const currentWeekStart = startOfWeek(todayStart, { weekStartsOn: 1 });
+      const weekDefs: { label: string; prevWeekKey: string }[] = [];
+      for (let i = 23; i >= 0; i--) {
+        const currentWeek = new Date(
+          currentWeekStart.getTime() - i * 7 * 24 * 60 * 60 * 1000,
+        );
+        const previousWeek = new Date(
+          currentWeek.getTime() - 7 * 24 * 60 * 60 * 1000,
+        );
+        const prevWeekKey = startOfWeek(previousWeek, { weekStartsOn: 1 })
+          .toISOString()
+          .split('T')[0];
+        const label = currentWeek.toISOString().split('T')[0];
+        weekDefs.push({ label, prevWeekKey });
+      }
+
+      // Construir la serie de 24 semanas solo para los productos que tuvieron
+      // ventas (el resto el forecasting los descarta de todos modos).
+      const result: Record<string, { week: string; totalSales: number }[]> = {};
+      for (const [productId, weeks] of salesByProduct) {
+        result[productId] = weekDefs.map(({ label, prevWeekKey }) => ({
+          week: label,
+          totalSales: weeks.get(prevWeekKey) || 0,
+        }));
+      }
+
+      return result;
+    } catch (error) {
+      throw new BadRequestException(
+        'Error al obtener las ventas semanales por lote',
+      );
+    }
+  }
+
   async getProductStockSummary() {
     try {
       const products = await this.prisma.product.findMany({

--- a/src/sales/sales.controller.ts
+++ b/src/sales/sales.controller.ts
@@ -47,6 +47,15 @@ export class SalesController {
     ) {
         return this.salesService.generateEInvoice(id, updateSaleDto);
     }
+
+    @UseGuards(AuthGuard)
+    @Patch('credit-note/:id')
+    async generateCreditNote(
+        @Param('id') id: string,
+        @Body() updateSaleDto: UpdateSaleDto
+    ) {
+        return this.salesService.generateCreditNote(id, updateSaleDto);
+    }
     
     @Get('user/:userId')
     async findByUserId(@Param('userId') userId: string) {

--- a/src/sales/sales.service.ts
+++ b/src/sales/sales.service.ts
@@ -335,15 +335,80 @@ export class SalesService {
 
       await this.brevoService.sendMailWithAttachment(
         sale.client.email,
-        4, // Reemplaza con el Template ID de Brevo (invoice-email)
+        4, // Template de Brevo (invoice-email); el cuerpo se ramifica con isCreditNote
         {
           clientName: sale.client.name,
           saleId: updatedSale.id,
+          isCreditNote: false,
         },
         [
           {
             content: pdf_sale.toString('base64'),
             filename: `factura-${updatedSale.id}.pdf`,
+            type: 'application/pdf',
+          },
+        ],
+      );
+
+      return updatedSale;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async generateCreditNote(id: string, updateSaleDto: UpdateSaleDto) {
+    try {
+      const { number_credit_note, cufe, qr_image } = updateSaleDto;
+      const sale = await this.findById(id);
+
+      if (!sale) {
+        throw new NotFoundException('Venta no encontrada');
+      }
+
+      const updatedSale = await this.prisma.sale.update({
+        where: { id },
+        data: {
+          number_credit_note,
+          cufe,
+          qr_image,
+        },
+        include: this.saleInclude,
+      });
+
+      // Generamos el PDF como NOTA DE CRÉDITO de forma explícita. La venta aún
+      // no está marcada como devuelta en este punto (eso ocurre en returnSale),
+      // por eso pasamos isCreditNote en vez de depender de sale.repaid.
+      const pdf_creditNote = await this.invoiceService.generateInvoicePdf({
+        isCreditNote: true,
+        sale: updatedSale,
+        clientFound: [
+          {
+            id: sale.client.id,
+            name: sale.client.name,
+            email: sale.client.email,
+          },
+        ],
+        detailedProducts: sale.products.map((product) => ({
+          name: product.products.name,
+          quantity: product.amount,
+          unitPrice: Number(product.products.price),
+          subtotal: product.amount * Number(product.products.price),
+        })),
+      });
+
+      await this.brevoService.sendMailWithAttachment(
+        sale.client.email,
+        4, // Mismo template de Brevo que la factura; el cuerpo se ramifica con isCreditNote
+        {
+          clientName: sale.client.name,
+          saleId: updatedSale.id,
+          creditNoteNumber: updatedSale.number_credit_note,
+          isCreditNote: true,
+        },
+        [
+          {
+            content: pdf_creditNote.toString('base64'),
+            filename: `nota-credito-${updatedSale.id}.pdf`,
             type: 'application/pdf',
           },
         ],

--- a/src/sales/scan.gateway.ts
+++ b/src/sales/scan.gateway.ts
@@ -9,7 +9,7 @@ import { Server, Socket } from 'socket.io';
 
 @WebSocketGateway({
     cors: {
-        origin: ['http://localhost:5173', 'https://www.drogueriane.site', 'https://drogueriane.site', 'https://app112.proyectos.fireploy.online'],
+        origin: ['http://localhost:5173', 'https://www.drogueriane.site', 'https://drogueriane.site', 'https://www.drogueriane.store', 'https://drogueriane.store', 'https://app112.proyectos.fireploy.online'],
         methods: ['GET', 'POST'],
     }
 })

--- a/src/templates/invoice-email.html
+++ b/src/templates/invoice-email.html
@@ -87,7 +87,7 @@
     <header
       style="display: flex; align-items: center; gap: 20px; margin-bottom: 30px"
     >
-      <h1 style="color: #2e7d32; margin: 0">Factura de venta</h1>
+      <h1 style="color: #2e7d32; margin: 0">{{documentTitle}}</h1>
       <img
         src="https://res.cloudinary.com/dcvikbhm6/image/upload/v1742098103/dzuvp1n5jnssnspkxs4t.png"
         class="logo"
@@ -109,9 +109,15 @@
 
       <div class="invoice-info">
         <strong>Fecha:</strong> {{date}}<br />
+        {{#isCreditNote}}
+        <strong>Nota de Crédito No: </strong>{{creditNoteNumber}}<br />
+        <strong>Factura de venta referenciada: </strong>{{invoiceENumber}}<br />
+        {{/isCreditNote}}
+        {{^isCreditNote}}
         <strong>N.º Factura:</strong> {{invoiceNumber}}<br />
         <strong>Factura Electrónica de Venta No: </strong
         >{{invoiceENumber}}<br />
+        {{/isCreditNote}}
         <strong>{{cufeLabel}}: </strong><span class="long-text">{{cufe}}</span><br />
       </div>
     </div>
@@ -143,7 +149,7 @@
 
     <div style="margin-top: 30px; text-align: center">
       {{#qrImage}}
-      <p>Escanee el código QR para ver la factura electrónica:</p>
+      <p>Escanee el código QR para ver {{#isCreditNote}}la nota de crédito{{/isCreditNote}}{{^isCreditNote}}la factura electrónica{{/isCreditNote}}:</p>
       <img src="{{qrImage}}" alt="Código QR" style="max-width: 150px" />
       {{/qrImage}} {{^qrImage}}
       <p><strong>El código QR no está disponible.</strong></p>
@@ -151,7 +157,12 @@
     </div>
 
     <div class="footer">
+      {{#isCreditNote}}
+      <p>Devolución procesada. Gracias por tu preferencia ❤️.</p>
+      {{/isCreditNote}}
+      {{^isCreditNote}}
       <p>Gracias por su compra ❤️.</p>
+      {{/isCreditNote}}
       Barrio Nueva Esperanza Av. 19<br />
       Tel: +57 3115883433
     </div>


### PR DESCRIPTION
## Summary

Brings the `omar-dev` branch into `main`. Includes the AI assistant migration to AWS Bedrock, lightweight names endpoints, and a couple of fixes found while testing.

### AI assistant → Claude via AWS Bedrock (`feat(ai)`)
- New `ai` module exposing `POST /api/ai/run`, protected with `AuthGuard` and validated via a DTO. The `{context, question, restrictions}` -> `{answer}` contract is unchanged, so the frontend needs no changes.
- Uses the official Anthropic Bedrock SDK (`@anthropic-ai/bedrock-sdk`). Business rules and context go in the system prompt; the user question is sent as a separate user message for better instruction following.
- Maps Bedrock errors (`429` throttling, `403` access/permission, `5xx`) to clear, user-facing messages.
- Strips asterisk markdown (bold, italics, bullets) from responses so the plain-text frontend never shows raw markers — covers both the chat and the prescriptive recommendations.
- Credentials come from the standard AWS chain (no keys in code). Model and region are configurable.

### Lightweight names endpoints (`perf`)
- `GET /product/names` and `GET /category/names` return only `id + name` (no heavy joins), to populate the forecasting selectors without the full `findAll` payload on every page load.

### Batched weekly-sales endpoint (`perf`)
- `GET /product/weekly-sales-batch` returns the 24-week weekly sales series for every product in a single DB query.
- Replaces the N+1 pattern in the forecasting job, which called `GET /product/weekly-sales/:id` once per product (~2000 requests every Monday). The job now makes a single request instead.
- The 24-week computation mirrors `getWeeklySalesLast6Months`, so per-product results are unchanged. This noticeably lowers the Monday memory/CPU spike on both the backend and the forecasting service.

### Returns send a credit note instead of the sale invoice (`fix(sales)`)
- The return flow reused the e-invoice endpoint, which always generated the sale-invoice PDF and emailed the invoice template, so customers received the original invoice again.
- New `generateCreditNote` service method and `PATCH /sales/credit-note/:id` endpoint that persists `number_credit_note` and renders the document as a credit note.
- The PDF template (`invoice-email.html`) is now conditional via `isCreditNote` (title, document number, CUDE/CUFE label, footer). `isCreditNote` is also passed to the Brevo params so the email body can branch.

### Client name in verification code email (`fix(client)`)
- `sendVerificationCode` only passed the code to the Brevo template, so `{{ params.name }}` rendered empty. It now looks up the client by email and passes the name (generic fallback when the client does not exist yet).

### Other commits
This branch also carries previously-unmerged commits (CORS fix, DB seed script, Railway/Dockerfile build fixes, SendGrid→Brevo email migration, etc.).

## Notes
Requires the following environment variables in the backend:
- `AWS_REGION` (e.g. `us-east-1`)
- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (IAM user with `bedrock:InvokeModel`)
- `BEDROCK_MODEL` (Bedrock inference profile id, e.g. `global.anthropic.claude-haiku-4-5-20251001-v1:0`)

The previous `GEMINI_API_KEY` / `GEMINI_MODEL` variables are no longer used and can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
